### PR TITLE
Fix VapoursynthDecoder does not apply variables

### DIFF
--- a/src/helpers/vapoursynth.rs
+++ b/src/helpers/vapoursynth.rs
@@ -184,9 +184,7 @@ impl VapoursynthDecoder {
         variables: HashMap<VariableName, VariableValue>,
     ) -> Result<VapoursynthDecoder, DecoderError> {
         let mut decoder = Self::new()?;
-        if let Some(variables) = variables {
-            decoder.set_variables(variables)?;
-        }
+        decoder.set_variables(variables)?;
         decoder
             .get_env()
             .eval_file(input, EvalFlags::SetWorkingDir)
@@ -303,9 +301,7 @@ impl VapoursynthDecoder {
         variables: HashMap<VariableName, VariableValue>,
     ) -> Result<VapoursynthDecoder, DecoderError> {
         let mut decoder = Self::new()?;
-        if let Some(variables) = variables {
-            decoder.set_variables(variables)?;
-        }
+        decoder.set_variables(variables)?;
         decoder.get_env().eval_script(script).map_err(|e| match e {
             vapoursynth::vsscript::Error::CStringConversion(_)
             | vapoursynth::vsscript::Error::FileOpen(_)

--- a/src/helpers/vapoursynth.rs
+++ b/src/helpers/vapoursynth.rs
@@ -180,7 +180,7 @@ impl VapoursynthDecoder {
     #[inline]
     pub fn from_file<P: AsRef<Path>>(
         input: P,
-        variables: Option<HashMap<VariableName, VariableValue>>,
+        variables: HashMap<VariableName, VariableValue>,
     ) -> Result<VapoursynthDecoder, DecoderError> {
         let mut decoder = Self::new()?;
         if let Some(variables) = variables {
@@ -298,7 +298,7 @@ impl VapoursynthDecoder {
     #[inline]
     pub fn from_script(
         script: &str,
-        variables: Option<HashMap<VariableName, VariableValue>>,
+        variables: HashMap<VariableName, VariableValue>,
     ) -> Result<VapoursynthDecoder, DecoderError> {
         let mut decoder = Self::new()?;
         if let Some(variables) = variables {

--- a/src/helpers/vapoursynth.rs
+++ b/src/helpers/vapoursynth.rs
@@ -120,7 +120,7 @@ impl VapoursynthDecoder {
     /// * `variables` - A `std::collections::HashMap<VariableName, VariableValue>`
     ///   containing the variable names and values to set. These will be passed to the
     ///   VapourSynth environment and can be accessed within the script using
-    ///   `vs.get_output()` or similar mechanisms. Pass `None` if no variables are needed.
+    ///   `vs.get_output()` or similar mechanisms. Pass `HashMap::new()` if no variables are needed.
     ///
     /// # Returns
     ///
@@ -152,6 +152,7 @@ impl VapoursynthDecoder {
     ///
     /// ```rust,no_run
     /// use av_decoders::VapoursynthDecoder;
+    /// use std::collections::HashMap;
     ///
     /// // Load a VapourSynth script file
     /// let decoder = VapoursynthDecoder::from_file("script.vpy")?;
@@ -159,7 +160,7 @@ impl VapoursynthDecoder {
     /// // Using PathBuf
     /// use std::path::PathBuf;
     /// let script_path = PathBuf::from("processing_script.vpy");
-    /// let decoder = VapoursynthDecoder::from_file(&script_path)?;
+    /// let decoder = VapoursynthDecoder::from_file(&script_path, HashMap::new())?;
     /// # Ok::<(), av_decoders::DecoderError>(())
     /// ```
     ///
@@ -225,7 +226,7 @@ impl VapoursynthDecoder {
     /// * `variables` - A `std::collections::HashMap<VariableName, VariableValue>`
     ///   containing the variable names and values to set. These will be passed to the
     ///   VapourSynth environment and can be accessed within the script using
-    ///   `vs.get_output()` or similar mechanisms. Pass `None` if no variables are needed.
+    ///   `vs.get_output()` or similar mechanisms. Pass `HashMap::new()` if no variables are needed.
     ///
     /// # Returns
     ///
@@ -258,6 +259,7 @@ impl VapoursynthDecoder {
     ///
     /// ```rust,no_run
     /// use av_decoders::VapoursynthDecoder;
+    /// use std::collections::HashMap;
     ///
     /// // Simple script that loads a video file
     /// let script = r#"
@@ -268,7 +270,7 @@ impl VapoursynthDecoder {
     /// clip.set_output()
     /// "#;
     ///
-    /// let decoder = VapoursynthDecoder::from_script(script)?;
+    /// let decoder = VapoursynthDecoder::from_script(script, HashMap::new())?;
     ///
     /// // More complex processing script
     /// let processing_script = r#"
@@ -287,7 +289,7 @@ impl VapoursynthDecoder {
     /// clip.set_output()
     /// "#;
     ///
-    /// let decoder = VapoursynthDecoder::from_script(processing_script)?;
+    /// let decoder = VapoursynthDecoder::from_script(processing_script, HashMap::new())?;
     /// # Ok::<(), av_decoders::DecoderError>(())
     /// ```
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,7 +212,7 @@ impl Decoder {
             #[cfg(feature = "vapoursynth")]
             if ext == "vpy" {
                 // Decode vapoursynth script file input
-                let decoder = DecoderImpl::Vapoursynth(VapoursynthDecoder::from_file(input)?);
+                let decoder = DecoderImpl::Vapoursynth(VapoursynthDecoder::from_file(input, None)?);
                 let video_details = decoder.video_details()?;
                 return Ok(Decoder {
                     decoder,
@@ -255,7 +255,7 @@ clip.set_output()
                         .to_string_lossy()
                 )
             );
-            let decoder = DecoderImpl::Vapoursynth(VapoursynthDecoder::from_script(&script)?);
+            let decoder = DecoderImpl::Vapoursynth(VapoursynthDecoder::from_script(&script, None)?);
             let video_details = decoder.video_details()?;
             return Ok(Decoder {
                 decoder,
@@ -387,10 +387,7 @@ clip.set_output()
         script: &str,
         variables: Option<HashMap<VariableName, VariableValue>>,
     ) -> Result<Decoder, DecoderError> {
-        let mut dec = VapoursynthDecoder::from_script(script)?;
-        if let Some(variables_map) = variables {
-            dec.set_variables(variables_map)?;
-        }
+        let mut dec = VapoursynthDecoder::from_script(script, variables)?;
         let decoder = DecoderImpl::Vapoursynth(dec);
         let video_details = decoder.video_details()?;
         Ok(Decoder {


### PR DESCRIPTION
Resolves #3

When `from_file` and `from_script` are evaluated, they are evaluated before any variables can be set and there is no mechanism to reevaluate (not necessary anyway) after setting variables.

Add optional variables parameter to from_file and from_script which will be set in the initialization *before* the script or file is evaluated.

This will require a minor version bump to be propagated downstream.

Thanks,
\- Boats M.

