### PR TITLE
Add VapourSynth Environment and Node Access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 0.10.0
+
+- feat!: add `output_index` option to `VapoursynthDecoder::from_file` and `VapoursynthDecoder::from_script`, this allows specifying which output node to decode
+
 ## Version 0.9.1
 
 - feat: add `Decoder::get_*_impl` methods

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "av-decoders"
-version = "0.9.1"
+version = "0.10.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Decoders for use in the rust-av ecosystem"

--- a/benches/decoders_bench.rs
+++ b/benches/decoders_bench.rs
@@ -85,14 +85,14 @@ clip.set_output(0)
         );
         // Create the decoder once to build the index file
         let _ = Decoder::from_decoder_impl(av_decoders::DecoderImpl::Vapoursynth(black_box(
-            VapoursynthDecoder::from_script(&script, HashMap::new()).unwrap(),
+            VapoursynthDecoder::from_script(&script, HashMap::new(), None).unwrap(),
         )))
         .unwrap();
 
         b.iter_batched(
             || {
                 Decoder::from_decoder_impl(av_decoders::DecoderImpl::Vapoursynth(black_box(
-                    VapoursynthDecoder::from_script(&script, HashMap::new()).unwrap(),
+                    VapoursynthDecoder::from_script(&script, HashMap::new(), None).unwrap(),
                 )))
                 .unwrap()
             },
@@ -122,7 +122,7 @@ clip.set_output(0)
         );
         // Create the decoder once to build the index file
         let initial_decoder = Decoder::from_decoder_impl(av_decoders::DecoderImpl::Vapoursynth(
-            black_box(VapoursynthDecoder::from_script(&script, HashMap::new()).unwrap()),
+            black_box(VapoursynthDecoder::from_script(&script, HashMap::new(), None).unwrap()),
         ))
         .unwrap();
         let initial_details = initial_decoder.get_video_details();
@@ -135,7 +135,7 @@ clip.set_output(0)
                 for i in 0..SIMULTANEOUS_DECODERS {
                     let decoder = Decoder::from_decoder_impl(
                         av_decoders::DecoderImpl::Vapoursynth(black_box(
-                            VapoursynthDecoder::from_script(&script, HashMap::new()).unwrap(),
+                            VapoursynthDecoder::from_script(&script, HashMap::new(), None).unwrap(),
                         )),
                     )
                     .unwrap();
@@ -188,14 +188,14 @@ clip.set_output(0)
         );
         // Create the decoder once to build the index file
         let _ = Decoder::from_decoder_impl(av_decoders::DecoderImpl::Vapoursynth(black_box(
-            VapoursynthDecoder::from_script(&script, HashMap::new()).unwrap(),
+            VapoursynthDecoder::from_script(&script, HashMap::new(), None).unwrap(),
         )))
         .unwrap();
 
         b.iter_batched(
             || {
                 Decoder::from_decoder_impl(av_decoders::DecoderImpl::Vapoursynth(black_box(
-                    VapoursynthDecoder::from_script(&script, HashMap::new()).unwrap(),
+                    VapoursynthDecoder::from_script(&script, HashMap::new(), None).unwrap(),
                 )))
                 .unwrap()
             },
@@ -228,14 +228,14 @@ clip.set_output(0)
         );
         // Create the decoder once to build the index file
         let _ = Decoder::from_decoder_impl(av_decoders::DecoderImpl::Vapoursynth(black_box(
-            VapoursynthDecoder::from_script(&script, HashMap::new()).unwrap(),
+            VapoursynthDecoder::from_script(&script, HashMap::new(), None).unwrap(),
         )))
         .unwrap();
 
         b.iter_batched(
             || {
                 let mut vapoursynth_decoder =
-                    VapoursynthDecoder::from_script(&script, HashMap::new()).unwrap();
+                    VapoursynthDecoder::from_script(&script, HashMap::new(), None).unwrap();
                 vapoursynth_decoder
                     .register_node_modifier(Box::new(move |core, node| {
                         // Node is expected to exist
@@ -372,14 +372,14 @@ clip.set_output(0)
         );
         // Create the decoder once to build the index file
         let _ = Decoder::from_decoder_impl(av_decoders::DecoderImpl::Vapoursynth(black_box(
-            VapoursynthDecoder::from_script(&script, HashMap::new()).unwrap(),
+            VapoursynthDecoder::from_script(&script, HashMap::new(), None).unwrap(),
         )))
         .unwrap();
 
         b.iter_batched(
             || {
                 Decoder::from_decoder_impl(av_decoders::DecoderImpl::Vapoursynth(black_box(
-                    VapoursynthDecoder::from_script(&script, HashMap::new()).unwrap(),
+                    VapoursynthDecoder::from_script(&script, HashMap::new(), None).unwrap(),
                 )))
                 .unwrap()
             },

--- a/src/helpers/vapoursynth.rs
+++ b/src/helpers/vapoursynth.rs
@@ -21,7 +21,7 @@ use vapoursynth::{
     vsscript::{Environment, EvalFlags},
 };
 
-const OUTPUT_INDEX: i32 = 0;
+const DEFAULT_OUTPUT_INDEX: i32 = 0;
 
 /// The type for the callback function used to modify the Vapoursynth node
 /// before it is used to decode frames. This allows the user to modify
@@ -65,13 +65,14 @@ pub struct VapoursynthDecoder {
     pub env: Environment,
     modify_node: Option<ModifyNode>,
     video_details: Option<VideoDetails>,
+    output_index: i32,
 }
 
 impl VapoursynthDecoder {
     /// Creates a new VapourSynth decoder from a new VapourSynth environment.
     ///
     /// This function creates a VapourSynth environment with no output. A valid output node
-    /// must be provided with the `register_node_modifier` function before the decodercan be used
+    /// must be provided with the `register_node_modifier` function before the decoder can be used
     /// to decode frames.
     ///
     /// # Returns
@@ -114,6 +115,7 @@ impl VapoursynthDecoder {
             env,
             modify_node: None,
             video_details: None,
+            output_index: DEFAULT_OUTPUT_INDEX,
         })
     }
 
@@ -131,6 +133,7 @@ impl VapoursynthDecoder {
     ///   containing the variable names and values to set. These will be passed to the
     ///   VapourSynth environment and can be accessed within the script using
     ///   `vs.get_output()` or similar mechanisms. Pass `HashMap::new()` if no variables are needed.
+    /// * `output_index` - The index of the output node to use for decoding. Defaults to 0.
     ///
     /// # Returns
     ///
@@ -165,12 +168,12 @@ impl VapoursynthDecoder {
     /// use std::collections::HashMap;
     ///
     /// // Load a VapourSynth script file
-    /// let decoder = VapoursynthDecoder::from_file("script.vpy", HashMap::new())?;
+    /// let decoder = VapoursynthDecoder::from_file("script.vpy", HashMap::new(), None)?;
     ///
     /// // Using PathBuf
     /// use std::path::PathBuf;
     /// let script_path = PathBuf::from("processing_script.vpy");
-    /// let decoder = VapoursynthDecoder::from_file(&script_path, HashMap::new())?;
+    /// let decoder = VapoursynthDecoder::from_file(&script_path, HashMap::new(), Some(1))?;
     /// # Ok::<(), av_decoders::DecoderError>(())
     /// ```
     ///
@@ -192,9 +195,13 @@ impl VapoursynthDecoder {
     pub fn from_file<P: AsRef<Path>>(
         input: P,
         variables: HashMap<VariableName, VariableValue>,
+        output_index: Option<u8>,
     ) -> Result<VapoursynthDecoder, DecoderError> {
         let mut decoder = Self::new()?;
         decoder.set_variables(variables)?;
+        if let Some(index) = output_index {
+            decoder.output_index = index as i32;
+        }
         decoder
             .get_env()
             .eval_file(input, EvalFlags::SetWorkingDir)
@@ -238,6 +245,8 @@ impl VapoursynthDecoder {
     ///   containing the variable names and values to set. These will be passed to the
     ///   VapourSynth environment and can be accessed within the script using
     ///   `vs.get_output()` or similar mechanisms. Pass `HashMap::new()` if no variables are needed.
+    /// * `output_index` - An optional `u8` value specifying the output node index in the script.
+    ///   Defaults to the first output node (`0`).
     ///
     /// # Returns
     ///
@@ -281,7 +290,7 @@ impl VapoursynthDecoder {
     /// clip.set_output()
     /// "#;
     ///
-    /// let decoder = VapoursynthDecoder::from_script(script, HashMap::new())?;
+    /// let decoder = VapoursynthDecoder::from_script(script, HashMap::new(), None)?;
     ///
     /// // More complex processing script
     /// let processing_script = r#"
@@ -292,15 +301,16 @@ impl VapoursynthDecoder {
     /// clip = core.ffms2.Source('raw_footage.mkv')
     ///
     /// # Apply denoising
-    /// clip = core.knlm.KNLMeansCL(clip, d=2, a=2, h=0.8)
+    /// processed_clip = core.knlm.KNLMeansCL(clip, d=2, a=2, h=0.8)
     ///
     /// # Resize to 1080p
-    /// clip = core.resize.Bicubic(clip, width=1920, height=1080)
+    /// processed_clip = core.resize.Bicubic(processed_clip, width=1920, height=1080)
     ///
     /// clip.set_output()
+    /// processed_clip.set_output(1)
     /// "#;
     ///
-    /// let decoder = VapoursynthDecoder::from_script(processing_script, HashMap::new())?;
+    /// let decoder = VapoursynthDecoder::from_script(processing_script, HashMap::new(), Some(1))?;
     /// # Ok::<(), av_decoders::DecoderError>(())
     /// ```
     ///
@@ -312,9 +322,13 @@ impl VapoursynthDecoder {
     pub fn from_script(
         script: &str,
         variables: HashMap<VariableName, VariableValue>,
+        output_index: Option<u8>,
     ) -> Result<VapoursynthDecoder, DecoderError> {
         let mut decoder = Self::new()?;
         decoder.set_variables(variables)?;
+        if let Some(index) = output_index {
+            decoder.output_index = index as i32;
+        }
         decoder.get_env().eval_script(script).map_err(|e| match e {
             vapoursynth::vsscript::Error::CStringConversion(_)
             | vapoursynth::vsscript::Error::FileOpen(_)
@@ -439,7 +453,7 @@ impl VapoursynthDecoder {
         }
 
         let node = {
-            let output_node = match self.env.get_output(OUTPUT_INDEX) {
+            let output_node = match self.env.get_output(self.output_index) {
                 Ok(output) => {
                     let (output_node, _) = output;
                     Some(output_node)
@@ -584,7 +598,7 @@ impl VapoursynthDecoder {
     ///
     /// Returns `vapoursynth::vsscript::Node`.
     pub(crate) fn get_output_node(&self) -> Node<'_> {
-        let output_node = match self.env.get_output(OUTPUT_INDEX) {
+        let output_node = match self.env.get_output(self.output_index) {
             Ok(output) => {
                 let (output_node, _) = output;
                 Some(output_node)
@@ -649,7 +663,7 @@ impl VapoursynthDecoder {
             })?;
 
         let output_node = {
-            let res = self.env.get_output(OUTPUT_INDEX);
+            let res = self.env.get_output(self.output_index);
             match res {
                 Ok((node, _)) => Some(node),
                 Err(vapoursynth::vsscript::Error::NoOutput) => None,

--- a/src/helpers/vapoursynth.rs
+++ b/src/helpers/vapoursynth.rs
@@ -63,7 +63,8 @@ pub type VariableValue = String;
 pub struct VapoursynthDecoder {
     #[allow(missing_docs)]
     pub env: Environment,
-    modify_node: Option<ModifyNode>,
+    #[allow(missing_docs)]
+    pub modify_node: Option<ModifyNode>,
     video_details: Option<VideoDetails>,
     output_index: i32,
 }
@@ -572,6 +573,18 @@ impl VapoursynthDecoder {
         }
 
         Ok(frame)
+    }
+
+    /// Get the VapourSynth environment.
+    ///
+    /// This function returns an immutable reference to the
+    /// VapourSynth environment created during initialization.
+    ///
+    /// # Returns
+    ///
+    /// Returns `&vapoursynth::vsscript::Environment`.
+    pub(crate) fn get_environment(&self) -> &Environment {
+        &self.env
     }
 
     /// Get the VapourSynth environment.

--- a/src/helpers/vapoursynth.rs
+++ b/src/helpers/vapoursynth.rs
@@ -64,7 +64,7 @@ pub struct VapoursynthDecoder {
     #[allow(missing_docs)]
     pub env: Environment,
     #[allow(missing_docs)]
-    pub modify_node: Option<ModifyNode>,
+    modify_node: Option<ModifyNode>,
     video_details: Option<VideoDetails>,
     output_index: i32,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -237,8 +237,11 @@ impl Decoder {
             #[cfg(feature = "vapoursynth")]
             if ext == "vpy" {
                 // Decode vapoursynth script file input
-                let decoder =
-                    DecoderImpl::Vapoursynth(VapoursynthDecoder::from_file(input, HashMap::new(), None)?);
+                let decoder = DecoderImpl::Vapoursynth(VapoursynthDecoder::from_file(
+                    input,
+                    HashMap::new(),
+                    None,
+                )?);
                 let video_details = decoder.video_details()?;
                 return Ok(Decoder {
                     decoder,
@@ -296,8 +299,11 @@ clip.set_output()
                         .to_string_lossy()
                 )
             );
-            let decoder =
-                DecoderImpl::Vapoursynth(VapoursynthDecoder::from_script(&script, HashMap::new(), None)?);
+            let decoder = DecoderImpl::Vapoursynth(VapoursynthDecoder::from_script(
+                &script,
+                HashMap::new(),
+                None,
+            )?);
             let video_details = decoder.video_details()?;
             return Ok(Decoder {
                 decoder,
@@ -942,6 +948,98 @@ clip.set_output()
     pub fn get_vapoursynth_node(&self) -> Result<Node<'_>, DecoderError> {
         match self.decoder {
             DecoderImpl::Vapoursynth(ref dec) => Ok(dec.get_output_node()),
+            _ => Err(DecoderError::UnsupportedDecoder),
+        }
+    }
+
+    /// Returns the VapourSynth Environment and video node representing the decoded video stream.
+    ///
+    /// This method provides access to the underlying VapourSynth `Node` that represents
+    /// the video source and the `Environment`. The node can be used for advanced VapourSynth operations,
+    /// creating additional processing pipelines, or integrating with other VapourSynth
+    /// workflows and tools.
+    ///
+    /// VapourSynth nodes are the fundamental building blocks of video processing
+    /// pipelines and can be used to:
+    /// - Apply additional filters and transformations
+    /// - Create branched processing pipelines
+    /// - Extract frame metadata and properties
+    /// - Implement custom frame processing logic
+    /// - Interface with other VapourSynth-based applications
+    ///
+    /// # Requirements
+    ///
+    /// This method is only available when:
+    /// - The `vapoursynth` feature is enabled
+    /// - The decoder is using the VapourSynth backend (created via `from_file()` with
+    ///   VapourSynth available, or via `from_script()`)
+    ///
+    /// # Returns
+    ///
+    /// Returns a `Result` containing:
+    /// - `Ok((Environment, Node))` - The VapourSynth environment and node representing the video stream
+    /// - `Err(DecoderError::UnsupportedDecoder)` - If the current decoder is not using VapourSynth
+    ///
+    /// # Errors
+    ///
+    /// This method will return an error if:
+    /// - The decoder was not initialized with VapourSynth (e.g., using Y4M or FFmpeg backend)
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use av_decoders::Decoder;
+    ///
+    /// let decoder = Decoder::from_file("video.mkv")?;
+    ///
+    /// // Get the VapourSynth node for advanced processing
+    /// if let Ok((env, node)) = decoder.get_vapoursynth_node() {
+    ///     // You can now use this environment and node for additional VapourSynth operations
+    ///     // Note: This example shows the concept - actual usage would depend
+    ///     // on specific VapourSynth operations you want to perform
+    ///
+    ///     println!("Got VapourSynth environment and node");
+    ///
+    ///     // Example: You could apply additional filters to this node
+    ///     // let filtered_node = apply_custom_filter(node);
+    ///
+    ///     // Or use it to create a new processing pipeline
+    ///     // let output_node = create_processing_pipeline(node);
+    /// 
+    ///     // You can also use the environment to create another node
+    ///     // let second_node = create_new_node(env);
+    ///     // compare_nodes(node, second_node);
+    /// }
+    /// # Ok::<(), av_decoders::DecoderError>(())
+    /// ```
+    ///
+    /// ## Advanced Usage
+    ///
+    /// ```no_run
+    /// # use av_decoders::Decoder;
+    /// # use std::collections::HashMap;
+    /// // Create a decoder from a script
+    /// let script = r#"
+    /// import vapoursynth as vs
+    /// core = vs.core
+    /// clip = core.ffms2.Source("input.mkv")
+    /// clip.set_output()
+    /// "#;
+    ///
+    /// let decoder = Decoder::from_script(script, HashMap::new())?;
+    ///
+    /// // Get the node and use it for further processing
+    /// let (env, node) = decoder.get_vapoursynth_node()?;
+    ///
+    /// // Now you can integrate this node into larger VapourSynth workflows
+    /// // or apply additional processing that wasn't included in the original script
+    /// # Ok::<(), av_decoders::DecoderError>(())
+    /// ```
+    #[inline]
+    #[cfg(feature = "vapoursynth")]
+    pub fn get_vapoursynth(&self) -> Result<(&Environment, Node<'_>), DecoderError> {
+        match self.decoder {
+            DecoderImpl::Vapoursynth(ref dec) => Ok((dec.get_environment(), dec.get_output_node())),
             _ => Err(DecoderError::UnsupportedDecoder),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1005,7 +1005,7 @@ clip.set_output()
     ///
     ///     // Or use it to create a new processing pipeline
     ///     // let output_node = create_processing_pipeline(node);
-    /// 
+    ///
     ///     // You can also use the environment to create another node
     ///     // let second_node = create_new_node(env);
     ///     // compare_nodes(node, second_node);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,7 +238,7 @@ impl Decoder {
             if ext == "vpy" {
                 // Decode vapoursynth script file input
                 let decoder =
-                    DecoderImpl::Vapoursynth(VapoursynthDecoder::from_file(input, HashMap::new())?);
+                    DecoderImpl::Vapoursynth(VapoursynthDecoder::from_file(input, HashMap::new(), None)?);
                 let video_details = decoder.video_details()?;
                 return Ok(Decoder {
                     decoder,
@@ -297,7 +297,7 @@ clip.set_output()
                 )
             );
             let decoder =
-                DecoderImpl::Vapoursynth(VapoursynthDecoder::from_script(&script, HashMap::new())?);
+                DecoderImpl::Vapoursynth(VapoursynthDecoder::from_script(&script, HashMap::new(), None)?);
             let video_details = decoder.video_details()?;
             return Ok(Decoder {
                 decoder,
@@ -432,7 +432,7 @@ clip.set_output()
         script: &str,
         variables: HashMap<VariableName, VariableValue>,
     ) -> Result<Decoder, DecoderError> {
-        let dec = VapoursynthDecoder::from_script(script, variables)?;
+        let dec = VapoursynthDecoder::from_script(script, variables, None)?;
         let decoder = DecoderImpl::Vapoursynth(dec);
         let video_details = decoder.video_details()?;
         Ok(Decoder {


### PR DESCRIPTION
Adds a new function to return both the Environment and Video Node. This avoids both mutably and immutably borrowing which makes the below example possible. `node_modifier` is now public to allow updating it after instantiation.

Also allows specifying an `output_index` in `VapoursynthDecoder` (defaults to 0, maintaining previous behavior) to select a specific Video Node when a script/environment produces multiple nodes.

## Example

```rs
let (env, reference_node) = decoder.get_vapoursynth();
let core = get_core(env);
let distorted_node = import_video(core);
let compared_node = compare_nodes(reference_node, distorted_node);
```
