### PR TITLE
Refactor VapourSynthDecoder to allow access to any output node

### DIFF
--- a/src/helpers/vapoursynth.rs
+++ b/src/helpers/vapoursynth.rs
@@ -298,30 +298,48 @@ impl VapoursynthDecoder {
     }
 
     /// Returns the VapourSynth output node, applying the registered modifier if any.
-    pub(crate) fn get_output_node(&self) -> Node<'_> {
-        let output_node = match self.env.get_output(self.output_index) {
+    #[inline]
+    #[must_use]
+    pub fn get_output_node(&self) -> Node<'_> {
+        self.get_output(self.output_index, true)
+            .expect("output node exists--validated during initialization")
+    }
+
+    /// Returns the VapourSynth output node at the specified index, optionally modifying it with the registered callback.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DecoderError::VapoursynthInternalError`] if the core cannot be obtained or no output node exists. Propagates any error from the callback itself.
+    #[inline]
+    pub fn get_output(&self, index: i32, modify: bool) -> Result<Node<'_>, DecoderError> {
+        let output_node = match self.env.get_output(index) {
             Ok(output) => {
                 let (output_node, _) = output;
-                Some(output_node)
+                Ok(Some(output_node))
             }
             Err(vapoursynth::vsscript::Error::NoOutput) => {
-                if self.modify_node.is_some() {
-                    None
+                if modify {
+                    Ok(None)
                 } else {
-                    panic!("output node does not exist");
+                    // panic!("output node does not exist");
+                    Err(map_vsscript_error(&vapoursynth::vsscript::Error::NoOutput))
                 }
             }
             Err(_) => panic!("unexpected error when getting output node"),
-        };
-        if let Some(modify_node) = self.modify_node.as_ref() {
+        }?;
+        if let Some(modify_node) = self.modify_node.as_ref()
+            && modify
+        {
             let core = self
                 .env
                 .get_core()
                 .expect("core exists--validated during initialization");
             modify_node(core, output_node)
-                .expect("modified node exists--validated during registration")
         } else {
-            output_node.expect("output node exists--validated during initialization")
+            output_node.map_or_else(
+                || Err(map_vsscript_error(&vapoursynth::vsscript::Error::NoOutput)),
+                Ok,
+            )
         }
     }
 

--- a/src/helpers/vapoursynth.rs
+++ b/src/helpers/vapoursynth.rs
@@ -298,27 +298,45 @@ impl VapoursynthDecoder {
     }
 
     /// Returns the VapourSynth output node, applying the registered modifier if any.
-    #[inline]
-    #[must_use]
-    pub fn get_output_node(&self) -> Node<'_> {
-        self.get_output(self.output_index, true)
+    pub(crate) fn get_output_node(&self) -> Node<'_> {
+        self.get_output(self.output_index, self.modify_node.as_ref())
             .expect("output node exists--validated during initialization")
     }
 
-    /// Returns the VapourSynth output node at the specified index, optionally modifying it with the registered callback.
+    /// Returns the index of the VapourSynth output node.
+    #[inline]
+    #[must_use]
+    pub fn get_output_index(&self) -> i32 {
+        self.output_index
+    }
+
+    /// Returns a reference to the registered modifier callback, if any.
+    #[inline]
+    #[must_use]
+    pub fn get_node_modifier(&self) -> Option<&ModifyNode> {
+        self.modify_node.as_ref()
+    }
+
+    /// Returns the VapourSynth output node at the specified index,
+    /// modifying it with the optional callback.
     ///
     /// # Errors
     ///
-    /// Returns [`DecoderError::VapoursynthInternalError`] if the core cannot be obtained or no output node exists. Propagates any error from the callback itself.
+    /// Returns [`DecoderError::VapoursynthInternalError`] if the core cannot be obtained
+    /// or no output node exists. Propagates any error from the callback itself.
     #[inline]
-    pub fn get_output(&self, index: i32, modify: bool) -> Result<Node<'_>, DecoderError> {
+    pub fn get_output(
+        &self,
+        index: i32,
+        modify_node: Option<&ModifyNode>,
+    ) -> Result<Node<'_>, DecoderError> {
         let output_node = match self.env.get_output(index) {
             Ok(output) => {
                 let (output_node, _) = output;
                 Ok(Some(output_node))
             }
             Err(vapoursynth::vsscript::Error::NoOutput) => {
-                if modify {
+                if modify_node.is_some() {
                     Ok(None)
                 } else {
                     // panic!("output node does not exist");
@@ -327,9 +345,7 @@ impl VapoursynthDecoder {
             }
             Err(_) => panic!("unexpected error when getting output node"),
         }?;
-        if let Some(modify_node) = self.modify_node.as_ref()
-            && modify
-        {
+        if let Some(modify_node) = modify_node {
             let core = self
                 .env
                 .get_core()


### PR DESCRIPTION
Adds a public (not `pub(crate)` ) method to `VapoursynthDecoder` to get a VideoNode at the specified index and optionally apply a node modifier. This requires the caller to know which index `VapoursynthDecoder` was instantiated with and have access to the registered node modifier, so 2 "getter" functions have been added.

The getter functions are the bare minimum to get output nodes exactly like `Decoder` gets. If Application A passes an already instantiated `Decoder` to Application B, Application B has no knowledge of what index or node modifier was used so it cannot retrieve the same (modified) output without changing its own API which could introduce unexpected behavior if there's a mismatch. The `get_output` method is just a convenience function that removes a lot of boilerplate without being restrictive.

### Examples

Before:

```rs
let vapoursynth_decoder = decoder.get_vapoursynth_impl().expect("Decoder is VapourSynth");
let core = vapoursynth_decoder.env.get_core()?;
let output_node = vapoursynth_decoder.env.get_output(MAGIC_INDEX)?.0; // How does this app know the output index if it didn't instantiate Decoder itself?
let node = MAGIC_MODIFY_NODE(core, output_node)?; // How does this app access the same node_modifier that was consumed when Decoder was instantiated? It can't because Node and Core can't implement Copy so it can't be cloned even if you wanted.
```

After:

```rs
let vapoursynth_decoder = decoder.get_vapoursynth_impl().expect("Decoder is VapourSynth");
let reference_node = vapoursynth_decoder.get_output(vapoursynth_decoder.get_output_index(), vapoursynth_decoder.get_node_modifier())?; // Identical to the existing pub(crate) get_output_node method
```

PlaneStats:

```rs
let Some(vapoursynth_decoder) = decoder.get_vapoursynth_impl() else {
    warnings.push(anyhow::Error::new(NoiseDetectorError::InvalidInput));
    return Ok(((), warnings));
};
let reference_node = vapoursynth_decoder.get_output(
    vapoursynth_decoder.get_output_index(),
    vapoursynth_decoder.get_node_modifier(),
)?;
let denoised_node = vapoursynth_decoder.get_output(1, vapoursynth_decoder.get_node_modifier())?;

let node = PlaneStats::default().call(core, &reference_node, Some(&denoised_node))?;
```

Quality Comparison:

```rs
let Some(vapoursynth_decoder) = decoder.get_vapoursynth_impl() else {
    // Err
};
let reference_node = vapoursynth_decoder.get_output(
    vapoursynth_decoder.get_output_index(),
    vapoursynth_decoder.get_node_modifier(),
)?;
let distorted_node = vapoursynth_decoder.get_output(1, vapoursynth_decoder.get_node_modifier())?;

let node = SSIMULACRA2::default().invoke(core, &reference_node, &distorted_node)?; // Nodes must be in the same Core/Environment, otherwise this doesn't work
SSIMULACRA2::get_scores(&node, None, compare_progress_tx)?
```